### PR TITLE
TMS support proposal

### DIFF
--- a/0.0.3/Readme.md
+++ b/0.0.3/Readme.md
@@ -129,19 +129,44 @@ MosaicJSON manifest file as invalid and refuse operation.
 
     // OPTIONAL. Default: null.
     // TileMatrixSet definition.
-    // One or:
-    // - Identifier string (which will be interpreted by the application)
-    // - TMS URL (e.g. https://raw.githubusercontent.com/developmentseed/morecantile/3.3.0/morecantile/data/WebMercatorQuad.json)
-    // - TMS document
-    // - TMS definition parameters (identifier + crs + extent + ...)
-    // as defined in https://developmentseed.org/morecantile/usage/#define-custom-grid.
-    "TileMatrixSet": {
-        "identifier": "WebMercatorQuad",
-        "extent": [0, 0, 100, 100],
-        "crs": "epsg:32132",
-        "tile_width": 256,
-        "tile_height": 256,
-        "matrix_scale": [1, 1]
+    "tilematrixset": {
+        "title": "LINZ NZTM2000Quad Map Tile Grid",
+        "abstract": "See https://github.com/linz/NZTM2000TileMatrixSet",
+        "id": "NZTM2000Quad",
+        "crs": "urn:ogc:def:crs:EPSG::2193",
+        "orderedAxes": [
+            "Y",
+            "X"
+        ],
+        "tileMatrices": [
+            {
+                "id": "0",
+                "scaleDenominator": 139770566.007179,
+                "pointOfOrigin": [
+                    10438190.1652,
+                    -3260586.7284
+                ],
+                "tileWidth": 256,
+                "tileHeight": 256,
+                "matrixWidth": 1,
+                "matrixHeight": 1,
+                "cellSize": 39135.75848201011
+            },
+            ...
+            {
+                "id": "21",
+                "scaleDenominator": 66.64779949530553,
+                "pointOfOrigin": [
+                    10438190.1652,
+                    -3260586.7284
+                ],
+                "tileWidth": 256,
+                "tileHeight": 256,
+                "matrixWidth": 2097152,
+                "matrixHeight": 2097152,
+                "cellSize": 0.018661383858685546
+            }
+        ]
     }
 }
 ```

--- a/0.0.3/Readme.md
+++ b/0.0.3/Readme.md
@@ -18,7 +18,7 @@ required and not valid or present, implementations MUST treat the entire
 MosaicJSON manifest file as invalid and refuse operation.
 
 
-```javascript
+```json
 {
     // REQUIRED. A semver.org style version number. Describes the version of
     // the MosaicJSON spec that is implemented by this JSON object.
@@ -125,6 +125,23 @@ MosaicJSON manifest file as invalid and refuse operation.
     // OPTIONAL. Default: null.
     // GDAL like colormap in form of {key: [r, g, b, a], ...}
     // In GDAL
-    "colormap": {}
+    "colormap": {},
+
+    // OPTIONAL. Default: null.
+    // TileMatrixSet definition.
+    // One or:
+    // - Identifier string (which will be interpreted by the application)
+    // - TMS URL (e.g. https://raw.githubusercontent.com/developmentseed/morecantile/3.3.0/morecantile/data/WebMercatorQuad.json)
+    // - TMS document
+    // - TMS definition parameters (identifier + crs + extent + ...)
+    // as defined in https://developmentseed.org/morecantile/usage/#define-custom-grid.
+    "TileMatrixSet": {
+        "identifier": "WebMercatorQuad",
+        "extent": [0, 0, 100, 100],
+        "crs": "epsg:32132",
+        "tile_width": 256,
+        "tile_height": 256,
+        "matrix_scale": [1, 1]
+    }
 }
 ```

--- a/0.0.3/example/dg_post_idai.json
+++ b/0.0.3/example/dg_post_idai.json
@@ -69,5 +69,265 @@
       "0032201.tif"
     ]
   },
-  "asset_prefix": "s3://opendata.remotepixel.ca/dg_post_idai/2019_03_20/"
+  "asset_prefix": "s3://opendata.remotepixel.ca/dg_post_idai/2019_03_20/",
+  "tilematrixset": {
+    "id": "WebMercatorQuad",
+    "title": "Google Maps Compatible for the World",
+    "uri": "http://www.opengis.net/def/tilematrixset/OGC/1.0/WebMercatorQuad",
+    "crs": "http://www.opengis.net/def/crs/EPSG/0/3857",
+    "orderedAxes": ["X", "Y"],
+    "wellKnownScaleSet": "http://www.opengis.net/def/wkss/OGC/1.0/GoogleMapsCompatible",
+    "tileMatrices": [
+      {
+        "id": "0",
+        "scaleDenominator": 559082264.028717,
+        "cellSize": 156543.033928041,
+        "pointOfOrigin": [-20037508.342789244,20037508.342789244],
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 1,
+        "matrixHeight": 1
+      },
+      {
+        "id": "1",
+        "scaleDenominator": 279541132.014358,
+        "cellSize": 78271.5169640204,
+        "pointOfOrigin": [-20037508.342789244,20037508.342789244],
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 2,
+        "matrixHeight": 2
+      },
+      {
+        "id": "2",
+        "scaleDenominator": 139770566.007179,
+        "cellSize": 39135.7584820102,
+        "pointOfOrigin": [-20037508.342789244,20037508.342789244],
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 4,
+        "matrixHeight": 4
+      },
+      {
+        "id": "3",
+        "scaleDenominator": 69885283.0035897,
+        "cellSize": 19567.8792410051,
+        "pointOfOrigin": [-20037508.342789244,20037508.342789244],
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 8,
+        "matrixHeight": 8
+      },
+      {
+        "id": "4",
+        "scaleDenominator": 34942641.5017948,
+        "cellSize": 9783.93962050256,
+        "pointOfOrigin": [-20037508.342789244,20037508.342789244],
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 16,
+        "matrixHeight": 16
+      },
+      {
+        "id": "5",
+        "scaleDenominator": 17471320.7508974,
+        "cellSize": 4891.96981025128,
+        "pointOfOrigin": [-20037508.342789244,20037508.342789244],
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 32,
+        "matrixHeight": 32
+      },
+      {
+        "id": "6",
+        "scaleDenominator": 8735660.37544871,
+        "cellSize": 2445.98490512564,
+        "pointOfOrigin": [-20037508.342789244,20037508.342789244],
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 64,
+        "matrixHeight": 64
+      },
+      {
+        "id": "7",
+        "scaleDenominator": 4367830.18772435,
+        "cellSize": 1222.99245256282,
+        "pointOfOrigin": [-20037508.342789244,20037508.342789244],
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 128,
+        "matrixHeight": 128
+      },
+      {
+        "id": "8",
+        "scaleDenominator": 2183915.09386217,
+        "cellSize": 611.49622628141,
+        "pointOfOrigin": [-20037508.342789244,20037508.342789244],
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 256,
+        "matrixHeight": 256
+      },
+      {
+        "id": "9",
+        "scaleDenominator": 1091957.54693108,
+        "cellSize": 305.748113140704,
+        "pointOfOrigin": [-20037508.342789244,20037508.342789244],
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 512,
+        "matrixHeight": 512
+      },
+      {
+        "id": "10",
+        "scaleDenominator": 545978.773465544,
+        "cellSize": 152.874056570352,
+        "pointOfOrigin": [-20037508.342789244,20037508.342789244],
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 1024,
+        "matrixHeight": 1024
+      },
+      {
+        "id": "11",
+        "scaleDenominator": 272989.386732772,
+        "cellSize": 76.4370282851762,
+        "pointOfOrigin": [-20037508.342789244,20037508.342789244],
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 2048,
+        "matrixHeight": 2048
+      },
+      {
+        "id": "12",
+        "scaleDenominator": 136494.693366386,
+        "cellSize": 38.2185141425881,
+        "pointOfOrigin": [-20037508.342789244,20037508.342789244],
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 4096,
+        "matrixHeight": 4096
+      },
+      {
+        "id": "13",
+        "scaleDenominator": 68247.346683193,
+        "cellSize": 19.109257071294,
+        "pointOfOrigin": [-20037508.342789244,20037508.342789244],
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 8192,
+        "matrixHeight": 8192
+      },
+      {
+        "id": "14",
+        "scaleDenominator": 34123.6733415964,
+        "cellSize": 9.55462853564703,
+        "pointOfOrigin": [-20037508.342789244,20037508.342789244],
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 16384,
+        "matrixHeight": 16384
+      },
+      {
+        "id": "15",
+        "scaleDenominator": 17061.8366707982,
+        "cellSize": 4.77731426782351,
+        "pointOfOrigin": [-20037508.342789244,20037508.342789244],
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 32768,
+        "matrixHeight": 32768
+      },
+      {
+        "id": "16",
+        "scaleDenominator": 8530.91833539913,
+        "cellSize": 2.38865713391175,
+        "pointOfOrigin": [-20037508.342789244,20037508.342789244],
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 65536,
+        "matrixHeight": 65536
+      },
+      {
+        "id": "17",
+        "scaleDenominator": 4265.45916769956,
+        "cellSize": 1.19432856695587,
+        "pointOfOrigin": [-20037508.342789244,20037508.342789244],
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 131072,
+        "matrixHeight": 131072
+      },
+      {
+        "id": "18",
+        "scaleDenominator": 2132.72958384978,
+        "cellSize": 0.597164283477939,
+        "pointOfOrigin": [-20037508.342789244,20037508.342789244],
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 262144,
+        "matrixHeight": 262144
+      },
+      {
+        "id": "19",
+        "scaleDenominator": 1066.36479192489,
+        "cellSize": 0.29858214173897,
+        "pointOfOrigin": [-20037508.342789244,20037508.342789244],
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 524288,
+        "matrixHeight": 524288
+      },
+      {
+        "id": "20",
+        "scaleDenominator": 533.182395962445,
+        "cellSize": 0.149291070869485,
+        "pointOfOrigin": [-20037508.342789244,20037508.342789244],
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 1048576,
+        "matrixHeight": 1048576
+      },
+      {
+        "id": "21",
+        "scaleDenominator": 266.591197981222,
+        "cellSize": 0.0746455354347424,
+        "pointOfOrigin": [-20037508.342789244,20037508.342789244],
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 2097152,
+        "matrixHeight": 2097152
+      },
+      {
+        "id": "22",
+        "scaleDenominator": 133.295598990611,
+        "cellSize": 0.0373227677173712,
+        "pointOfOrigin": [-20037508.342789244,20037508.342789244],
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 4194304,
+        "matrixHeight": 4194304
+      },
+      {
+        "id": "23",
+        "scaleDenominator": 66.6477994953056,
+        "cellSize": 0.0186613838586856,
+        "pointOfOrigin": [-20037508.342789244,20037508.342789244],
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 8388608,
+        "matrixHeight": 8388608
+      },
+      {
+        "id": "24",
+        "scaleDenominator": 33.3238997476528,
+        "cellSize": 0.0093306919293428,
+        "pointOfOrigin": [-20037508.342789244,20037508.342789244],
+        "tileWidth": 256,
+        "tileHeight": 256,
+        "matrixWidth": 16777216,
+        "matrixHeight": 16777216
+      }
+    ]
+  }
 }

--- a/0.0.3/schema.json
+++ b/0.0.3/schema.json
@@ -65,7 +65,7 @@
         },
         "data_type": {
             "type": "string",
-            "oneOf": [
+            "enum": [
                 "int8",
                 "int16",
                 "int32",
@@ -94,6 +94,10 @@
                     "maxItems": 4
                 }
             }
+        },
+        "tilematrixset": {
+            "description": "Tile matrix set definition",
+            "$ref": "https://raw.githubusercontent.com/opengeospatial/2D-Tile-Matrix-Set/master/schemas/tms/2.0/json/tileMatrixSet.json"
         }
     },
     "required": ["mosaicjson", "tiles", "minzoom", "maxzoom", "bounds"]


### PR DESCRIPTION
ref #13 

This PR adds `TileMatrixSet` entry to the MosaicJSON document.

As with the firs commit in the PR, I've decided to have a `full` set of option for the definition of the TileMatrixSet
- string **Identifier** (which will get interpreted by the application, e.g. WebMercatorQuad)
- TMS document URL
- full TMS document 
- Custom TMS options (only extent and CRS should be required which should be compatible with other application than morecantile)

This might be over complicated and we could go with only the TMS URL and Identifier


cc @sharkinsspatial @kylebarron @drwelby @AndrewAnnex @jlaura