### PR TITLE
add layers

### DIFF
--- a/0.0.3/Readme.md
+++ b/0.0.3/Readme.md
@@ -281,3 +281,25 @@ TileMatrixSet used for the `quadkey` definition. The TMS document should be comp
   }
 }
 ```
+
+## 3.17 `layers`
+
+OPTIONAL. Object.
+
+A set of `layer` configurations. Implementations MAY use the entries to define a set of available `layers` and use the configuration to create tiles.
+
+```JSON
+{
+  "layers": {
+    "true_color": {
+      "bidx": ["b1", "b2", "b3"],
+      "color_formula": "Gamma RGB 3.5 Saturation 1.7 Sigmoidal RGB 15 0.35",
+    },
+    "ndvi": {
+      "expression": "(b4-b1)/(b4+b1)",
+      "rescale": "-1,1",
+      "colormap_name": "viridis"
+    }
+  }
+}
+```

--- a/0.0.3/schema.json
+++ b/0.0.3/schema.json
@@ -98,6 +98,10 @@
         "tilematrixset": {
             "description": "Tile matrix set definition",
             "$ref": "https://raw.githubusercontent.com/opengeospatial/2D-Tile-Matrix-Set/master/schemas/tms/2.0/json/tileMatrixSet.json"
+        },
+        "layers": {
+            "description": "A set of `layer` configurations",
+            "type": "object"
         }
     },
     "required": ["mosaicjson", "tiles", "minzoom", "maxzoom", "bounds"]


### PR DESCRIPTION
This PR adds a `layers` entry in the mosaicJSON spec.

The `layers` MAY or MAY NOT be used by implementations.

The `layers` entry CAN be used to:
- advertise a list of layers, user can construct with the `assets`
- pass info to the tiler for the tile creation

This is similar to https://stac-utils.github.io/titiler-pgstac/advanced/metadata/